### PR TITLE
Remove nic_type support from the XO client since it was causing test failures

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -80,7 +80,6 @@ type Vm struct {
 	ResourceSet        string            `json:"resourceSet,omitempty"`
 	// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
 	// SecureBoot         bool              `json:"secureBoot,omitempty"`
-	NicType    string   `json:"nicType,omitempty"`
 	Tags       []string `json:"tags"`
 	Videoram   Videoram `json:"videoram,omitempty"`
 	Vga        string   `json:"vga,omitempty"`
@@ -190,7 +189,6 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		"CPUs":             vmReq.CPUs.Number,
 		"memoryMax":        vmReq.Memory.Static[1],
 		"existingDisks":    existingDisks,
-		"nicType":          vmReq.NicType,
 		// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
 		// "secureBoot":       vmReq.SecureBoot,
 		"expNestedHvm": vmReq.ExpNestedHvm,
@@ -291,7 +289,6 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		"high_availability": vmReq.HA, // valid options are best-effort, restart, ''
 		"CPUs":              vmReq.CPUs.Number,
 		"memoryMax":         vmReq.Memory.Static[1],
-		"nicType":           vmReq.NicType,
 		"expNestedHvm":      vmReq.ExpNestedHvm,
 		"startDelay":        vmReq.StartDelay,
 		"vga":               vmReq.Vga,


### PR DESCRIPTION
This was reverted in https://github.com/terra-farm/terraform-provider-xenorchestra/pull/175 since it had a bug that caused all the acceptance tests to fail. I spent some time trying to debug it but since there are a few changes in flight for the xenorchestra provider, I decided the best thing was to revert it for now.

## Testing done
- [x] `make testacc` passes in against the terraform-provider-xenorchestra repo when the go module was updated to use this diff

```
# Verify that I used this diff
ddelnano@ddelnano-desktop:~/code/terraform-provider-xenorchestra$ git diff
diff --git a/go.mod b/go.mod
index ec62204..905b82b 100644
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
        github.com/vatesfr/xo-sdk-go v0.0.0-20211117083644-f5fff1f340a0
 )

-// replace github.com/vatesfr/xo-sdk-go => ../xo-sdk-go
+replace github.com/vatesfr/xo-sdk-go => ../xo-sdk-go

# Verify that the local repo is on this branch
ddelnano@ddelnano-desktop:~/code/terraform-provider-xenorchestra$ cd ../xo-sdk-go/
ddelnano@ddelnano-desktop:~/code/xo-sdk-go$ gs
On branch remove-nic_type-from-vm-client
nothing to commit, working tree clean

```